### PR TITLE
Add support for Windows userprofile paths with whitespace

### DIFF
--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -36,12 +36,35 @@ function InstallComposerForWin(path)
         error(err)
     end
 
-    local code = os.execute(path .. '\\php.exe ' .. setup .. ' --install-dir=' .. path)
+    local phpPath = path .. "\\php.exe"
+    local setupPath = setup
+    local installPath = path
+    local execString = phpPath .. ' ' .. setupPath .. ' --install-dir=' .. installPath
+    
+
+    if RUNTIME.osType == 'windows' then
+        phpPath = "\"" .. phpPath .. "\""
+        setupPath = "\"" .. setupPath .. "\""
+        installPath = "\"" .. installPath .. "\""
+        
+        local winPrefix = ''
+
+        util.write_file(path .. '\\composer_install.bat', winPrefix .. phpPath .. ' ' .. setupPath .. ' --install-dir=' .. installPath)
+
+        execString = path .. '\\composer_install.bat'
+    end
+
+    local code = os.execute(execString)
     if code ~= 0 then
         error('Failed to install composer.')
     end
 
     os.remove(setup)
+
+    if RUNTIME.osType == 'windows' then
+        os.remove(path .. '\\composer_install.bat')
+    end
+
     util.write_file(path .. '\\composer.bat', '@php "%~dp0composer.phar" %*')
 end
 


### PR DESCRIPTION
The installation of composer failed when the path to the user directory contained whitespace, which is quite common under Windows. This pull request fixes this. Under Unix-style systems the program for creating users usually enforces that there are no whitespace characters in the username. All GitHub-Actions workflows complete successfully.