### PR TITLE
Add --with-xsl flag and libxsl library for XSL support

### DIFF
--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install vfox
 
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y autoconf bison build-essential curl gettext git libgd-dev libcurl4-openssl-dev libedit-dev libicu-dev libjpeg-dev libmysqlclient-dev libonig-dev libpng-dev libpq-dev libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libzip-dev openssl pkg-config re2c zlib1g-dev
+        run: sudo apt-get update && sudo apt-get install -y autoconf bison build-essential curl gettext git libgd-dev libcurl4-openssl-dev libedit-dev libicu-dev libjpeg-dev libmysqlclient-dev libonig-dev libpng-dev libpq-dev libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libxslt-dev libzip-dev openssl pkg-config re2c zlib1g-dev
 
       - name: Generate PHP plugin
         run: |

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -26,7 +26,7 @@ jobs:
           zip -r php.zip ./
 
       - name: Install packages
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip pkg-config re2c zlib
+        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libxslt libzip pkg-config re2c zlib
 
       - name: Test
         shell: bash

--- a/bin/install
+++ b/bin/install
@@ -19,6 +19,7 @@ install_php() {
     local krb5_path=$(homebrew_package_path krb5)
     local libedit_path=$(homebrew_package_path libedit)
     local libxml2_path=$(homebrew_package_path libxml2)
+    local libxslt_path=$(homebrew_package_path libxslt)
     local openssl_path=$(homebrew_package_path openssl@1.1)
 
     if [ -n "$bison_path" ]; then
@@ -39,6 +40,10 @@ install_php() {
 
     if [ -n "$libxml2_path" ]; then
       export "PKG_CONFIG_PATH=${libxml2_path}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+    fi
+
+    if [ -n "$libxslt_path" ]; then
+      export "PKG_CONFIG_PATH=${libxslt_path}/lib/pkgconfig:${PKG_CONFIG_PATH}"
     fi
 
     if [ -n "$openssl_path" ]; then
@@ -183,6 +188,7 @@ os_based_configure_options() {
     local libedit_path=$(homebrew_package_path libedit)
     local libpng_path=$(homebrew_package_path libpng)
     local libxml2_path=$(homebrew_package_path libxml2)
+    local libxslt_path=$(homebrew_package_path libxslt)
     local libzip_path=$(homebrew_package_path libzip)
     local openssl_path=$(homebrew_package_path openssl@1.1)
     local readline_path=$(homebrew_package_path readline)
@@ -238,6 +244,10 @@ os_based_configure_options() {
       configure_options="$configure_options --with-libxml-dir=$libxml2_path"
     fi
 
+    if [ -n "$libxslt_path" ]; then
+      configure_options="$configure_options --with-xsl=$libxslt_path"
+    fi
+
     if [ -n "$zlib_path" ]; then
       configure_options="$configure_options --with-zlib-dir=$zlib_path"
     fi
@@ -264,7 +274,7 @@ os_based_configure_options() {
   else
     local jpeg_path=$(locate libjpeg.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
     local libpng_path=$(locate libpng.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
-    configure_options="--with-openssl --with-curl --with-zlib --with-readline --with-gettext"
+    configure_options="--with-openssl --with-curl --with-zlib --with-readline --with-gettext --with-xsl"
 
     if [ -n "$jpeg_path" ]; then
       configure_options="$configure_options --with-jpeg-dir=$jpeg_path --with-jpeg"


### PR DESCRIPTION
Other extensions like `amqp `or `imagick` can be enabled using pecl/pear packages, however xsl requires php to be compiled with the `--with-xsl` option.

This branch adds support for installing libxsl and enables the configuration option on php build.
ref: https://www.php.net/manual/en/xsl.installation.php