### PR TITLE
feat: support lts releases in linux

### DIFF
--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -39,10 +39,10 @@ function PLUGIN:PreInstall(ctx)
 end
 
 function GetReleaseForWindows(versions)
-    url = WIN_URL .. versions.name
+    url = WIN_RELEASES_URL .. versions.name
 
     if (versions.is_from_lts) then
-        url = WIN_URL_LTS .. versions.name
+        url = WIN_RELEASES_URL_LTS .. versions.name
     end
     return {
         version = versions.version,

--- a/lib/constants.lua
+++ b/lib/constants.lua
@@ -1,3 +1,5 @@
-URL = 'https://www.php.net/'
-WIN_URL = 'https://windows.php.net/downloads/releases/archives/'
-WIN_URL_LTS = 'https://windows.php.net/downloads/releases/'
+URL = 'https://www.php.net'
+RELEASES_URL = URL .. '/releases'
+RELEASES_URL_LTS = URL .. '/downloads'
+WIN_RELEASES_URL = 'https://windows.php.net/downloads/releases/archives/'
+WIN_RELEASES_URL_LTS = 'https://windows.php.net/downloads/releases/'

--- a/lib/constants.lua
+++ b/lib/constants.lua
@@ -1,5 +1,5 @@
 URL = 'https://www.php.net'
-RELEASES_URL = URL .. '/releases'
-RELEASES_URL_LTS = URL .. '/downloads'
+RELEASES_URL = URL .. '/releases/'
+RELEASES_URL_LTS = URL .. '/downloads.php'
 WIN_RELEASES_URL = 'https://windows.php.net/downloads/releases/archives/'
 WIN_RELEASES_URL_LTS = 'https://windows.php.net/downloads/releases/'


### PR DESCRIPTION
It was unable to install LTS versions of PHP because it was not listed in https://www.php.net/releases/, which only includes "Unsupported Historical Releases".

```
$ vfox --debug install php@8.4.8
CallFunction: PreInstall
plugin [PreInstall] method error: /home/risu/.version-fox/plugin/php/hooks/pre_install.lua:31: version not found for provided version 8.4.8
stack traceback:
        [G]: in function 'error'
        /home/risu/.version-fox/plugin/php/hooks/pre_install.lua:31: in main chunk
        [G]: ?
failed to install php
```

This PR adds https://www.php.net/downloads.php as the source of versions to support LTS versions.