### PR TITLE
fix: add User-Agent header to requests

### DIFF
--- a/hooks/available.lua
+++ b/hooks/available.lua
@@ -19,7 +19,7 @@ function GetReleaseListForWindows()
     local urls = { WIN_URL, WIN_URL_LTS }
 
     for _, url in ipairs(urls) do
-        local resp, err = http.get({ url = url })
+        local resp, err = http.get({ url = url, headers = { ["User-Agent"] = "vfox" } })
 
         if resp then
             local doc = html.parse(resp.body)


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/5373. (mise uses `vfox-php` internally)

It seems `windows.php.net` requires `User_Agent`, so this PR adds it to the reqeust to avoid errors.

```
$ curl -H "User-Agent:" https://windows.php.net/downloads/releases/archives/
20/feb/2018: Hi! We seem to be receiving high volume requests coming from empty user agents. While this shouldn't be an issue, this unfortunately resulted in bandwidth issues on this server causing all downloads to be unavailable. We've therefore decided to temporarily block empty user agents until we upgraded our server bandwidth.

03/mar/2018: We've upgraded the server bandwidth. This is however still not sufficient to handle all empty user agent connections. Please update the user agent in your scripts accordingly or contact us so we can discuss it.

Thank you for your understanding.

$ curl -H "User-Agent:" https://windows.php.net/downloads/releases/
20/feb/2018: Hi! We seem to be receiving high volume requests coming from empty user agents. While this shouldn't be an issue, this unfortunately resulted in bandwidth issues on this server causing all downloads to be unavailable. We've therefore decided to temporarily block empty user agents until we upgraded our server bandwidth.

03/mar/2018: We've upgraded the server bandwidth. This is however still not sufficient to handle all empty user agent connections. Please update the user agent in your scripts accordingly or contact us so we can discuss it.

Thank you for your understanding.
```

I followed https://github.com/version-fox/vfox-python/pull/3/files, and just used `vfox` as `User-Agent`.